### PR TITLE
Add internal store

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,46 +252,18 @@ Just like with an `<InertiaLink>`, you can control the history control behaviour
 
 ## Accessing page data in other components
 
-Sometimes it's necessary to access the page data (props) from a non-page component. One really common use-case for this is the site layout. For example, maybe you want to show the currently authenticated user in your site header. This is possible using React's context feature. The base Inertia component automatically provides the current page via context, which can then be accessed by a consumer later on.
+Sometimes it's necessary to access the page data (props) from a non-page component. One really common use-case for this is the site layout. For example, maybe you want to show the currently authenticated user in your site header. This is possible using Svelte's store feature.
 
-The easiest way to access page props is with our `pageProps` store.
-
-~~~svelte
-<script>
-  import { InertiaLink, pageProps } from 'inertia-svelte'
-  
-  $: ({ auth } = $pageProps)
-</script>
-
-<main>
-  <header>
-    You are logged in as: {auth.user.name}
-
-    <nav>
-      <InertiaLink href="/">Home</InertiaLink>
-      <InertiaLink href="/about">About</InertiaLink>
-      <InertiaLink href="/contact">Contact</InertiaLink>
-    </nav>
-  </header>
-
-  <article>
-    <slot />
-  </article>
-</main>
-~~~
-
-If you need to access the entire Inertia `page` object, you can directly access it via the `page` store. Note that `pageProps` should suffice for most use cases, so we don't recommend doing this unless you have a good reason!
+The easiest way to access page props is with our `page` store.
 
 ~~~svelte
 <script>
   import { InertiaLink, page } from 'inertia-svelte'
-
-  $: props = $page.props
 </script>
 
 <main>
   <header>
-    You are logged in as: {props.auth.user.name}
+    You are logged in as: {$page.auth.user.name}
 
     <nav>
       <InertiaLink href="/">Home</InertiaLink>
@@ -339,9 +311,9 @@ If your page contains multiple components using the remember functionality, you'
 
 ~~~svelte
 <script>
-  import { Inertia, pageProps, remember } from 'inertia-svelte'
+  import { Inertia, page, remember } from 'inertia-svelte'
 
-  $: ({ user } = $pageProps)
+  $: ({ user } = $page)
 
   let form = remember({
     first_name: null,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
   import Inertia from 'inertia'
-  import page from './page'
+  import store from './store'
 
   export let
     initialPage,
@@ -11,9 +11,9 @@
     initialPage,
     resolveComponent,
     updatePage: (component, props) => {
-      page.set({ component, props: transformProps(props) })
+      store.set({ component, props: transformProps(props) })
     },
   })
 </script>
 
-<svelte:component this={$page.component} {...$page.props} />
+<svelte:component this={$store.component} {...$store.props} />

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,7 @@ import Inertia from 'inertia'
 import App from './App.svelte'
 import InertiaLink from './Link.svelte'
 import page from './page'
-import pageProps from './pageProps'
 import remember from './remember'
 
 export default App
-export { Inertia, InertiaLink, page, pageProps, remember }
+export { Inertia, InertiaLink, page, remember }

--- a/src/page.js
+++ b/src/page.js
@@ -1,8 +1,6 @@
-import { writable } from 'svelte/store'
+import { derived } from 'svelte/store'
+import store from './store'
 
-const page = writable({
-  component: null,
-  props: {},
-})
+const page = derived(store, $store => $store.props)
 
 export default page

--- a/src/pageProps.js
+++ b/src/pageProps.js
@@ -1,6 +1,0 @@
-import { derived } from 'svelte/store'
-import page from './page'
-
-const pageProps = derived(page, $page => $page.props)
-
-export default pageProps

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,8 @@
+import { writable } from 'svelte/store'
+
+const store = writable({
+  component: null,
+  props: {},
+})
+
+export default store


### PR DESCRIPTION
@reinink proposed to rename `pageProps` to `page` to keep names consistent across Inertia adapters.

`page` is a writable store used internally to keep track of Inertia state. Right now it's exported and allows users to change its values. @reinink and I agree that it might be better to keep this state under the hood. This PR renames it to `store` and does not export it anymore.

`pageProps` is a derived (read-only) store. It inherits its value from `page`. This PR renames it to `page` to be consistent with the Vue adapter. It continues to be read-only.