### PR TITLE
Add support for preserveState

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,10 +10,16 @@
   Inertia.init({
     initialPage,
     resolveComponent,
-    updatePage: (component, props) => {
-      store.set({ component, props: transformProps(props) })
+    updatePage: (component, props, { preserveState }) => {
+      store.update(page => ({
+        component,
+        key: preserveState ? page.key : Date.now(),
+        props: transformProps(props),
+      }))
     },
   })
 </script>
 
+{#each [$store.key] as key (key)}
 <svelte:component this={$store.component} {...$store.props} />
+{/each}

--- a/src/store.js
+++ b/src/store.js
@@ -2,6 +2,7 @@ import { writable } from 'svelte/store'
 
 const store = writable({
   component: null,
+  key: null,
   props: {},
 })
 


### PR DESCRIPTION
Up until now `InertiaLink` accepted the `preserveState` prop but it didn't actually work because Svelte doesn't support keyed non-each components.

This PR implements a [workaround](https://github.com/sveltejs/svelte/issues/1469) that does the trick while an official solution isn't added to Svelte.