### PR TITLE
Fix svelte compile error

### DIFF
--- a/src/Link.svelte
+++ b/src/Link.svelte
@@ -11,7 +11,7 @@
     replace = false,
     preserveScroll = false,
     preserveState = false,
-    only = [],
+    only = []
 
   $: props = (({ data, href, method, preserveScroll, preserveState, replace, only, ...rest }) => rest)($$props)
 


### PR DESCRIPTION
There is an unexpected `,` after only. Make it compile fail. 
This PR is to fix this issued.

@reinink @sebastiandedeyne 

